### PR TITLE
Use feature detection instead of version detection

### DIFF
--- a/lib/utility/version.py
+++ b/lib/utility/version.py
@@ -6,5 +6,6 @@
 try:   # 如果小于Python3
     reload(sys)
     sys.setdefaultencoding("utf-8")
+    PYTHON_3 = False
 except NameError:
-    pass
+    PYTHON_3 = True

--- a/lib/utility/version.py
+++ b/lib/utility/version.py
@@ -3,13 +3,8 @@
 # author: zengyuetian
 
 
-import sys
-
-if sys.version_info < (3, 0):   # 如果小于Python3
-    PYTHON_3 = False
-else:
-    PYTHON_3 = True
-
-if not PYTHON_3:   # 如果小于Python3
+try:   # 如果小于Python3
     reload(sys)
     sys.setdefaultencoding("utf-8")
+except NameError:
+    pass


### PR DESCRIPTION
Follows the Python porting best practice [___use feature detection instead of version detection___](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).

__reload()__ was moved and __sys.setdefaultencoding()__ was removed in Python 3.